### PR TITLE
Expose more options into playbook vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Simple role to install the Gogs git server.
 * ``gitea_config_dir``: Folder in which to put gitea config (default: ``/etc/gitea``)
 * ``gitea_version``: The version of gitea to install (default: ``1.0.0``)
 * ``gitea_http_listen_addr``: The address to listen on for http request (default: '')
-
+* ``gitea_max_file_upload_size``: Max size of each file in MB. (default: '3')
+* ``gitea_explore_paging_num``: Number of repositories that are showed in one explore page (default: '20')
+* ``gitea_issue_paging_num``: Number of issues that are showed in one page (default: '10')
 
 ## Contributing
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,6 @@ gitea_database_uri: 'localhost:3306'
 gitea_database_name: gitea
 gitea_database_user: gitea
 gitea_http_listen_addr: ''
+gitea_max_file_upload_size: 3
+gitea_explore_paging_num: 20
+gitea_issue_paging_num: 10

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,6 +117,6 @@
 - name: Help user
   debug:
     msg: >
-      Find your gitea at http://{{ gitea_domain }}:3000
+      Find your gitea at http://{{ gitea_domain }}:{{ gitea_http_port }}
       To create an initial user, you need to temporarily set
       DISABLE_REGISTRATION=false in {{ gitea_config_dir }}/app.ini

--- a/templates/builtin_app.ini.j2
+++ b/templates/builtin_app.ini.j2
@@ -40,15 +40,15 @@ TEMP_PATH = data/tmp/uploads
 ; One or more allowed types, e.g. image/jpeg|image/png. Nothing means any file type
 ALLOWED_TYPES =
 ; Max size of each file in MB. Defaults to 3MB
-FILE_MAX_SIZE = 3
+FILE_MAX_SIZE = {{ gitea_max_file_upload_size }}
 ; Max number of files per upload. Defaults to 5
 MAX_FILES = 5
 
 [ui]
 ; Number of repositories that are showed in one explore page
-EXPLORE_PAGING_NUM = 20
+EXPLORE_PAGING_NUM = {{ gitea_explore_paging_num }}
 ; Number of issues that are showed in one page
-ISSUE_PAGING_NUM = 10
+ISSUE_PAGING_NUM = {{ gitea_issue_paging_num }}
 ; Number of maximum commits showed in one activity feed
 FEED_MAX_COMMIT_NUM = 5
 ; Value of `theme-color` meta tag, used by Android >= 5.0


### PR DESCRIPTION
Also fixes final message to user, using specified port.

Seeing as ideally user will never touch the app.ini by hand, sending this PR that exposes more options in the playbook.

I'm adding `master` as base since `next` seems behind.